### PR TITLE
Update run_baselines.py

### DIFF
--- a/3_stance_detection/2_Stance_model/baselines/run_baselines.py
+++ b/3_stance_detection/2_Stance_model/baselines/run_baselines.py
@@ -33,12 +33,11 @@ import keras.backend
 from keras.utils import to_categorical
 
 def label2float(x):
-    if x == 0:
-        return 1.0
-    elif x == 2:
-        return -1.0
-    else:
-        return 0.0
+    return {
+        0: 1.0,
+        2: -1.0,
+    }.get(x, 0.0)
+
 
 
 def classif_report(preds, labels):


### PR DESCRIPTION
changed label2float function maps integer values to specific floating point numbers. Here's a more efficient version using a dictionary for constant-time lookups